### PR TITLE
relax windows pin so a newer version can be pulled in

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,4 +12,4 @@ supports         'windows'
 
 depends          'ubuntu'
 depends          'java', '~> 1.17'
-depends          'windows', '~> 1.38.3'
+depends          'windows', '~> 1.38'


### PR DESCRIPTION
This allows pulling in newer versions of the windows cookbook. windows is up to 1.44.x at this point.