### PR TITLE
Fix flyway_migrate not working on wrapper cookbooks

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,7 @@ default['flyway']['jdbc_driver']['jtds']['version'] = "1.3.1"
 default['flyway']['init_on_migrate'] = "false"
 default['flyway']['include_java_recipe'] = true
 default['flyway']['properties_permissions'] = 0640
+default['flyway']['properties_template_cookbook'] = 'flyway-cli'
 
 default['flyway']['version_installed'] = "0"
 default['flyway']['old_base_url'] = "http://repo1.maven.org/maven2/com/googlecode/flyway/flyway-commandline/VERSION/flyway-commandline-VERSION.tar.gz"

--- a/definitions/flyway_migrate.rb
+++ b/definitions/flyway_migrate.rb
@@ -33,6 +33,7 @@ define :flyway_migrate do
     raise "password not defined for #{key} (using databag=#{confs['use_data_bag']}" unless password
 
     template "#{installation_path}/conf/#{key}.properties" do
+      cookbook node['flyway']['properties_template_cookbook']
       source 'flyway.properties.erb'
       mode node['flyway']['properties_permissions']
       # if user/group not overridden, will default to executing user


### PR DESCRIPTION
* Use attribute to specify from which cookbook load flyway.properties.erb

Fix #15