### PR TITLE
travis: chefdk to v1.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   matrix:
   - INSTANCE=default-ubuntu-1404
 
-before_install: curl -L https://www.getchef.com/chef/install.sh | sudo bash -s -- -P chefdk -v 0.16.28
+before_install: curl -L https://www.getchef.com/chef/install.sh | sudo bash -s -- -P chefdk -v 1.0.3
 install: chef exec bundle install --jobs=3 --retry=3
 
 # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142455888


### PR DESCRIPTION
Should fix `Gem::InstallError: buff-extensions requires Ruby version >= 2.2.0.`